### PR TITLE
Remove defaultOrder import from @typescript-eslint/member-ordering

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
-const {
-  defaultOrder,
-} = require("@typescript-eslint/eslint-plugin/dist/rules/member-ordering");
-
 const eslintConfig = {
   extends: [
     "@rushstack/eslint-config/profile/web-app",
@@ -68,7 +64,12 @@ const eslintConfig = {
     "@typescript-eslint/explicit-member-accessibility": "off",
     "@typescript-eslint/member-ordering": [
       "warn",
-      { default: { memberTypes: defaultOrder, order: "alphabetically" } },
+      {
+        default: {
+          memberTypes: ["signature", "field"],
+          order: "alphabetically",
+        },
+      },
     ],
     "@typescript-eslint/naming-convention": "off",
     "@typescript-eslint/no-floating-promises": "off",


### PR DESCRIPTION
The import is problematic since in some projects
@typescript-eslint/eslint-plugin ends up nested in another package’s
node_modules.

We don’t need the full default config so we can replace the imported
value with a simpler hard-coded value.

Closes #19